### PR TITLE
Magus backbone

### DIFF
--- a/sepp/exhaustive_upp.py
+++ b/sepp/exhaustive_upp.py
@@ -121,7 +121,7 @@ class UPPExhaustiveAlgorithm(ExhaustiveAlgorithm):
         _LOG.info("Writing backbone set. ")
         backbone = get_temp_file("backbone", "backbone", ".fas")
         _write_fasta(backbone_sequences, backbone)
-        if(hasattr(options(), "magus")):
+        if(hasattr(options(), "magus") and hasattr(options(), "fasttree")):
             # run MAGUS and fasttree
             magus_output_filename = self.get_output_filename("magus.fasta")
             magusalign_job = MAGUSAlignJob()

--- a/sepp/exhaustive_upp.py
+++ b/sepp/exhaustive_upp.py
@@ -199,7 +199,7 @@ class UPPExhaustiveAlgorithm(ExhaustiveAlgorithm):
             }
             if(isinstance(source_namespace.decomp_only, str)):
                 upp2_configs = {flag: bool(distutils.util.strtobool(upp2_configs[flag])) for flag in upp2_configs}
-            if(hasattr(source_namespace, "ensemble_path")):
+            if(hasattr(source_namespace, "ensemble_path") and source_namespace.ensemble_path != False):
                 upp2_configs["ensemble_path"] = source_namespace.ensemble_path
             for (k, v) in upp2_configs.items():
                 upp2_namespace.__setattr__(k, v)
@@ -467,11 +467,11 @@ class UPPExhaustiveAlgorithm(ExhaustiveAlgorithm):
                 self.filtered_taxa))
 
     def build_jobs(self):
-        if hasattr(options(), "upp2") and not hasattr(options().upp2, "ensemble_path"):
+        if not hasattr(options(), "upp2") or (hasattr(options(), "upp2") and not hasattr(options().upp2, "ensemble_path")):
             super().build_jobs()
 
     def build_subproblems(self):
-        if hasattr(options(), "upp2") and not hasattr(options().upp2, "ensemble_path"):
+        if not hasattr(options(), "upp2") or (hasattr(options(), "upp2") and not hasattr(options().upp2, "ensemble_path")):
             return super().build_subproblems()
 
     def connect_jobs(self):

--- a/sepp/exhaustive_upp.py
+++ b/sepp/exhaustive_upp.py
@@ -15,7 +15,7 @@ from timeit import default_timer
 from sepp import get_logger
 from sepp.alignment import MutableAlignment, ExtendedAlignment, _write_fasta
 from sepp.exhaustive import JoinAlignJobs, ExhaustiveAlgorithm
-from sepp.jobs import PastaAlignJob
+from sepp.jobs import PastaAlignJob,MAGUSAlignJob,FastTreeJob
 from sepp.filemgr import get_temp_file,get_root_temp_dir
 from sepp.config import options, valid_decomp_strategy
 import sepp.config
@@ -121,28 +121,47 @@ class UPPExhaustiveAlgorithm(ExhaustiveAlgorithm):
         _LOG.info("Writing backbone set. ")
         backbone = get_temp_file("backbone", "backbone", ".fas")
         _write_fasta(backbone_sequences, backbone)
+        if(hasattr(options(), "magus")):
+            # run MAGUS and fasttree
+            magus_output_filename = self.get_output_filename("magus.fasta")
+            magusalign_job = MAGUSAlignJob()
+            magusalign_job.setup(backbone, magus_output_filename)
+            _LOG.info("Running MAGUS backbone")
+            magusalign_job.run()
+            _LOG.info(f"MAGUS should be written to {magus_output_filename}")
 
-        _LOG.info("Generating pasta backbone alignment and tree. ")
-        pastaalign_job = PastaAlignJob()
-        molecule_type = options().molecule
-        if options().molecule == 'amino':
-            molecule_type = 'protein'
-        pastaalign_job.setup(backbone, options().backbone_size,
-                             molecule_type, options().cpu,
-                             **vars(options().pasta))
-        pastaalign_job.run()
-        (a_file, t_file) = pastaalign_job.read_results()
+            fasttree_output_filename = self.get_output_filename("magus_fasttree.tree")
+            fasttree_job = FastTreeJob()
+            fasttree_job.setup(magus_output_filename, fasttree_output_filename, self.molecule)
+            _LOG.info("Running FastTree backbone")
+            fasttree_job.run()
+            _LOG.info(f"FastTree should be written to {fasttree_output_filename}")
+            options().placement_size = self.options.backbone_size
+            options().alignment_file = open(magus_output_filename)
+            options().tree_file = open(fasttree_output_filename)
+        else:
+            _LOG.info("Generating pasta backbone alignment and tree. ")
+            pastaalign_job = PastaAlignJob()
+            molecule_type = options().molecule
+            if options().molecule == 'amino':
+                molecule_type = 'protein'
+            pastaalign_job.setup(backbone, options().backbone_size,
+                                 molecule_type, options().cpu,
+                                 **vars(options().pasta))
+            pastaalign_job.run()
+            (a_file, t_file) = pastaalign_job.read_results()
 
-        shutil.copyfile(t_file, self.get_output_filename("pasta.fasttree"))
-        shutil.copyfile(a_file, self.get_output_filename("pasta.fasta"))
+            shutil.copyfile(t_file, self.get_output_filename("pasta.fasttree"))
+            shutil.copyfile(a_file, self.get_output_filename("pasta.fasta"))
 
-        options().placement_size = self.options.backbone_size
-        options().alignment_file = open(
-            self.get_output_filename("pasta.fasta"))
-        options().tree_file = open(self.get_output_filename("pasta.fasttree"))
+            options().placement_size = self.options.backbone_size
+            options().alignment_file = open(
+                self.get_output_filename("pasta.fasta"))
+            options().tree_file = open(self.get_output_filename("pasta.fasttree"))
+
         _LOG.info(
-            "Backbone alignment written to %s.\nBackbone tree written to %s"
-            % (options().alignment_file, options().tree_file))
+                "Backbone alignment written to %s.\nBackbone tree written to %s"
+                % (options().alignment_file, options().tree_file))
         sequences.set_alignment(fragments)
         if len(sequences) == 0:
             sequences = MutableAlignment()
@@ -224,7 +243,8 @@ class UPPExhaustiveAlgorithm(ExhaustiveAlgorithm):
                 )
         ):
             # assert no parallelization when decomp_only
-            # TODO: restore old cpu value
+            # TODO: it doesn't seem that restoring old cpu value is necessary
+            # since JobPool() is called empty as a singleton class
             options().cpu = 1
         # TODO: check that hier_upp is True whenever early_stop is True
 

--- a/sepp/hmm_concurrent.py
+++ b/sepp/hmm_concurrent.py
@@ -886,6 +886,7 @@ def generateNewHMM(abstract_algorithm, strategyName):
         hmmName = get_root_temp_dir() + "/data/internalData/" + dataFolderName + "/" + strategyName + "/newHMM/hmm/" + str(a) + ".hmm"
         ensureFolder(hmmName)
         addHMMBuildJob(abstract_algorithm, hmmName, src)
+    _LOG.debug(f"JobPool actual cpus: {JobPool().cpus}")
     JobPool().wait_for_all_jobs()
 
 

--- a/sepp/jobs.py
+++ b/sepp/jobs.py
@@ -730,6 +730,46 @@ class FastTreeJob(ExternalSeppJob):
         return self.output_file
 
 
+class MAGUSAlignJob(ExternalSeppJob):
+    """
+    The Job class that generates a MAGUS alignment
+    """
+    def __init__(self, **kwargs):
+        self.job_type = "python"
+        ExternalSeppJob.__init__(self, self.job_type)
+        self.input_file = None  # input sequences
+        self.output_file = None  # output tree
+        self.magus_path =sepp.config.options().__getattribute__("magus").path
+
+    def setup(self, input_file, output_file):
+        """
+        """
+        self.input_file = input_file
+        self.output_file = output_file
+
+    def setup_for_subproblem(self):
+        """
+        Use setup for generating backbone tree
+        """
+        return
+
+    def get_invocation(self):
+        invoc = [self.path, self.magus_path, "-i", self.input_file, "-o", self.output_file]
+        return invoc
+
+    def characterize_input(self):
+        return "magus %s %s " % (
+            self.input_file, self.output_file)
+
+    def read_results(self):
+        """
+        Check and return file
+        """
+        assert os.path.exists(self.output_file)
+        assert os.stat(self.output_file)[stat.ST_SIZE] != 0
+        return self.output_file
+
+
 class PastaAlignJob(ExternalSeppJob):
     """
     The Job class that generates a Pasta alignment and tree

--- a/trial/1000M4/R0/test_with_upp2.config
+++ b/trial/1000M4/R0/test_with_upp2.config
@@ -1,12 +1,12 @@
 [commandline]
-# sequence_file=./trial/1000M4/R0/true_unalign_fragged.txt
-sequence_file=./trial/1000M4/R0/unaligned_frag_interleaved.txt
-alignment=./trial/1000M4/R0/pasta_backbone_align.txt
-tree=./trial/1000M4/R0/pasta_backbone.tre
+sequence_file=./trial/1000M4/R0/true_unalign_fragged.txt
+# sequence_file=./saved_ensemble/fragment_chunks/fragment_chunk_testtest.fasta
+# alignment=./trial/1000M4/R0/pasta_backbone_align.txt
+# tree=./trial/1000M4/R0/pasta_backbone.tre
 backboneSize=500
 alignmentSize=10
-molecule=dna
-cpu=10
+molecule=amino
+cpu=1
 tempdir=./tmp/
 outdir=./output/
 
@@ -14,4 +14,14 @@ outdir=./output/
 decomp_only=True
 bitscore_adjust=True
 hier_upp=True
-early_stop = False
+early_stop=True
+# ensemble_path=./saved_ensemble/
+#
+[python]
+path=/opt/QuickScripts/env/bin/python
+
+[magus]
+path=/projects/tallis/minhyuk2/git_repos/MAGUS/magus.py
+
+[fasttree]
+path=/opt/fasttree/FastTreeMP


### PR DESCRIPTION
This PR does two things
1. It fixes a bug with not being able to run default UPP using this repository when using a certain combination of flags
2. It enables magus and fasttree backbone estimation when given unaligned sequences as long as the paths for python, magus, and fasttree are given